### PR TITLE
add label and call_link_label to wc

### DIFF
--- a/aiida_ddec/workchains/cp2k_ddec.py
+++ b/aiida_ddec/workchains/cp2k_ddec.py
@@ -58,6 +58,8 @@ class Cp2kDdecWorkChain(WorkChain):
 
         cp2k_base_inputs = AttributeDict(self.exposed_inputs(Cp2kBaseWorkChain, 'cp2k_base'))
         cp2k_base_inputs['cp2k']['parameters'] = merge_Dict(cp2k_base_inputs['cp2k']['parameters'], param_modify)
+        cp2k_base_inputs['metadata']['label'] = 'cp2k_energy'
+        cp2k_base_inputs['metadata']['call_link_label'] = 'call_cp2k_energy'
         running = self.submit(Cp2kBaseWorkChain, **cp2k_base_inputs)
         self.report('Running Cp2kBaseWorkChain to compute the charge-density')
         return ToContext(cp2k_calc=running)
@@ -71,6 +73,7 @@ class Cp2kDdecWorkChain(WorkChain):
         ddec_inputs = AttributeDict(self.exposed_inputs(DdecCalculation, 'ddec'))
         ddec_inputs['charge_density_folder'] = self.ctx.cp2k_calc.outputs.remote_folder.creator.outputs.remote_folder
         ddec_inputs['parameters'] = merge_Dict(ddec_inputs['parameters'], core_e)
+        ddec_inputs['metadata']['call_link_label'] = 'call_ddec_calc'
 
         # Create the calculation process and launch it
         running = self.submit(DdecCalculation, **ddec_inputs)


### PR DESCRIPTION
Useful to get a better inspection of the WC inner working:
```
Called               PK  Type
----------------  -----  ----------------
call_ddec_calc    53968  CalcJobNode
CALL              53966  WorkFunctionNode
CALL              53964  WorkFunctionNode
call_cp2k_energy  53959  WorkChainNode
CALL              53957  WorkFunctionNode
```
Labelling the link to a relevant process should become a good/mandatory practice. 
Other CALL are to `merge_Dict` and `extract_core_electrons` that are secondary sub-processes that do not need any particular identification.